### PR TITLE
[MINOR] Fix broken ipynb nbviewer link

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ PHATE - Visualizing Transitions and Structure for Biological Data Exploration
 ### Quick Start
 If you would like to get started using PHATE, check out the following tutorials.
 
-* [**Guided tutorial in Python**](http://nbviewer.jupyter.org/github/KrishnaswamyLab/PHATE/blob/master/Python/tutorial/EmbryoidBody.ipynb)  
+* [**Guided tutorial in Python**](http://nbviewer.jupyter.org/github/KrishnaswamyLab/PHATE/blob/main/Python/tutorial/EmbryoidBody.ipynb)  
 * [**Guided turorial in R**](http://htmlpreview.github.io/?https://github.com/KrishnaswamyLab/phateR/blob/master/inst/examples/bonemarrow_tutorial.html)
 
 ### Introduction


### PR DESCRIPTION
The nbviewer link is currently broken because uses `master` instead of `main`